### PR TITLE
Report as many token/parse errors as possible

### DIFF
--- a/src/fountain/_cli.py
+++ b/src/fountain/_cli.py
@@ -4,7 +4,7 @@ import sys
 from typing import Any
 
 from ._ast import parse, tokenize
-from ._exceptions import EvalError, ParseError, TokenizeError
+from ._exceptions import EvalError, ParseErrors, TokenizeErrors
 from ._interpreter import Interpreter, stringify
 
 
@@ -41,12 +41,14 @@ class CLI:
     def run(self, source: str) -> int:
         try:
             self.evaluate(source)
-        except TokenizeError as exc:
-            self._report(exc.message, lineno=exc.lineno)
+        except TokenizeErrors as exc:
+            for t_exc in exc.errors:
+                self._report(t_exc.message, lineno=t_exc.lineno)
             return 65
-        except ParseError as exc:
-            where = "at end" if exc.at_eof else f"at {exc.token.lexeme!r}"
-            self._report(exc.message, lineno=exc.token.lineno, where=where)
+        except ParseErrors as exc:
+            for p_exc in exc.errors:
+                where = "at end" if p_exc.at_eof else f"at {p_exc.token.lexeme!r}"
+                self._report(p_exc.message, lineno=p_exc.token.lineno, where=where)
             return 65
         except EvalError as exc:
             where = f"at {exc.token.lexeme!r}"

--- a/src/fountain/_exceptions.py
+++ b/src/fountain/_exceptions.py
@@ -11,6 +11,12 @@ class TokenizeError(RuntimeError):
         self.message = message
 
 
+class TokenizeErrors(RuntimeError):
+    def __init__(self, errors: list[TokenizeError]) -> None:
+        super().__init__()
+        self.errors = errors
+
+
 class ParseError(RuntimeError):
     def __init__(self, token: "Token", message: str) -> None:
         super().__init__(message)
@@ -22,6 +28,12 @@ class ParseError(RuntimeError):
         from ._ast import TokenType
 
         return self.token.type == TokenType.EOF
+
+
+class ParseErrors(RuntimeError):
+    def __init__(self, errors: list[ParseError]) -> None:
+        super().__init__()
+        self.errors = errors
 
 
 class EvalError(RuntimeError):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -254,6 +254,35 @@ def test_cli_eval(source: str, result: str, capsys: Any) -> None:
             "[line 1] error: at 'return': return outside function\n",
             65,
         ),
+        pytest.param(
+            """
+            x = "valid"
+            !412
+            y = "valid"
+            §invalid
+            """,
+            (
+                "[line 3] error: invalid character: '!'\n"
+                "[line 5] error: invalid character: '§'\n"
+            ),
+            65,
+            id="token-error-multiple",
+        ),
+        pytest.param(
+            """
+            fn valid() end
+            valid())
+            y = "valid"
+            break
+            z = "ok"
+            """,
+            (
+                "[line 3] error: at ')': expected expression\n"
+                "[line 5] error: at 'break': break outside loop\n"
+            ),
+            65,
+            id="parse-error-multiple",
+        ),
         # Runtime errors
         (
             "1/0",


### PR DESCRIPTION
Refine error reporting so that as many token/parse errors as possible are reported, instead of the first one.

This puts the `synchronize()` mechanism in the parser to use: when a parse error occurs, we clean up and move on to the next statement, then carry on.