### PR TITLE
Add block variable resolution

### DIFF
--- a/src/fountain/_ast/__init__.py
+++ b/src/fountain/_ast/__init__.py
@@ -21,6 +21,7 @@ from .nodes import (
     Variable,
 )
 from .parse import parse
+from .resolve import resolve
 from .tokens import Token, TokenType, tokenize
 from .visitor import NodeVisitor
 
@@ -44,6 +45,7 @@ __all__ = [
     "Unary",
     "Variable",
     "parse",
+    "resolve",
     "Return",
     "Stmt",
     "Token",

--- a/src/fountain/_ast/resolve.py
+++ b/src/fountain/_ast/resolve.py
@@ -1,0 +1,152 @@
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any, Iterator
+
+from .nodes import (
+    Assert,
+    Assign,
+    Binary,
+    Block,
+    Break,
+    Call,
+    Conjunction,
+    Continue,
+    Disjunction,
+    Expression,
+    For,
+    Function,
+    Group,
+    If,
+    Literal,
+    Return,
+    Stmt,
+    Token,
+    Unary,
+    Variable,
+)
+from .visitor import NodeVisitor
+
+if TYPE_CHECKING:
+    from .._interpreter import Interpreter
+
+
+def resolve(interpreter: "Interpreter", statements: list[Stmt]) -> None:
+    resolver = Resolver(interpreter)
+    for stmt in statements:
+        resolver.execute(stmt)
+
+
+class Resolver(NodeVisitor[Any]):
+    """
+    Keep track of which scope a variable references belong to.
+
+    This is implemented by traversing the syntax tree, taking note of
+    the depth (global, scope 0, scope 1, ...) at which variable declaration
+    (assignment, function definition) or usage occurs.
+
+    This information is fed to the interpreter so that it evaluates variables
+    from the appropriate scope (which may be different from the scope at the
+    time of execution).
+    """
+
+    def __init__(self, interpreter: "Interpreter") -> None:
+        self._interpreter = interpreter
+        self._scopestack: list[dict[str, bool]] = []
+
+    @contextmanager
+    def _scope(self) -> Iterator[None]:
+        self._scopestack.append({})
+        yield
+        self._scopestack.pop()
+
+    def _define(self, name: Token) -> None:
+        if not self._scopestack:
+            return
+        current_scope = self._scopestack[-1]
+        current_scope[name.lexeme] = True
+
+    # Statements.
+
+    def execute_Block(self, stmt: Block) -> None:
+        with self._scope():
+            for s in stmt.statements:
+                self.execute(s)
+
+    def execute_If(self, stmt: If) -> None:
+        self.evaluate(stmt.test)
+        for s in stmt.body:
+            self.execute(s)
+        for s in stmt.orelse:
+            self.execute(s)
+
+    def execute_For(self, stmt: For) -> None:
+        for s in stmt.body:
+            self.execute(s)
+
+    def execute_Break(self, stmt: Break) -> None:
+        pass
+
+    def execute_Continue(self, stmt: Continue) -> None:
+        pass
+
+    def execute_Function(self, stmt: Function) -> None:
+        self._define(stmt.name)
+
+        with self._scope():
+            for param in stmt.parameters:
+                self._define(param)
+            for s in stmt.body:
+                self.execute(s)
+
+    def execute_Return(self, stmt: Return) -> None:
+        if stmt.expr is not None:
+            self.evaluate(stmt.expr)
+
+    def execute_Assert(self, stmt: Assert) -> None:
+        self.evaluate(stmt.test)
+        if stmt.message is not None:
+            self.evaluate(stmt.message)
+
+    def execute_Assign(self, stmt: Assign) -> None:
+        self._define(stmt.target)
+        self.evaluate(stmt.value)
+
+    def execute_Expression(self, stmt: Expression) -> None:
+        self.evaluate(stmt.expression)
+
+    # Expressions.
+
+    def evaluate_Disjunction(self, expr: Disjunction) -> None:
+        for exp in expr.expressions:
+            self.evaluate(exp)
+
+    def evaluate_Conjunction(self, expr: Conjunction) -> None:
+        for exp in expr.expressions:
+            self.evaluate(exp)
+
+    def evaluate_Binary(self, expr: Binary) -> None:
+        self.evaluate(expr.left)
+        self.evaluate(expr.right)
+
+    def evaluate_Unary(self, expr: Unary) -> None:
+        self.evaluate(expr.right)
+
+    def evaluate_Call(self, expr: Call) -> None:
+        self.evaluate(expr.callee)
+        for arg in expr.pos_args:
+            self.evaluate(arg)
+        for value in expr.kw_values:
+            self.evaluate(value)
+
+    def evaluate_Literal(self, expr: Literal) -> None:
+        pass
+
+    def evaluate_Group(self, expr: Group) -> None:
+        self.evaluate(expr.expression)
+
+    def evaluate_Variable(self, expr: Variable) -> None:
+        # Let the interpreter know which depth the variable is located at.
+        # Walk up from inner-most to outer-most scope.
+        for depth, scope in enumerate(reversed(self._scopestack)):
+            if expr.name.lexeme in scope:
+                self._interpreter.on_resolve(expr, depth)
+                break

--- a/src/fountain/_cli.py
+++ b/src/fountain/_cli.py
@@ -43,13 +43,12 @@ class CLI:
 
         try:
             statements = parse(tokens)
+            resolve(self._interpreter, statements)
         except ParseErrors as exc:
             for p_exc in exc.errors:
                 where = "at end" if p_exc.at_eof else f"at {p_exc.token.lexeme!r}"
                 self._report(p_exc.message, lineno=p_exc.token.lineno, where=where)
             raise
-
-        resolve(self._interpreter, statements)
 
         try:
             return self._interpreter.interpret(statements)

--- a/src/fountain/_cli.py
+++ b/src/fountain/_cli.py
@@ -3,7 +3,7 @@ import pathlib
 import sys
 from typing import Any
 
-from ._ast import parse, tokenize
+from ._ast import parse, resolve, tokenize
 from ._exceptions import EvalError, ParseErrors, TokenizeErrors
 from ._interpreter import Interpreter, stringify
 
@@ -48,6 +48,8 @@ class CLI:
                 where = "at end" if p_exc.at_eof else f"at {p_exc.token.lexeme!r}"
                 self._report(p_exc.message, lineno=p_exc.token.lineno, where=where)
             raise
+
+        resolve(self._interpreter, statements)
 
         try:
             return self._interpreter.interpret(statements)

--- a/src/fountain/_scope.py
+++ b/src/fountain/_scope.py
@@ -1,4 +1,4 @@
-from typing import Any
+from typing import Any, Optional
 
 from ._ast import Token
 from ._exceptions import EvalError
@@ -9,6 +9,10 @@ class Scope:
         self._parent = parent
         self._values: dict[str, Any] = {}
 
+    @property
+    def parent(self) -> Optional["Scope"]:
+        return self._parent
+
     def assign(self, name: str, value: Any) -> None:
         self._values[name] = value
 
@@ -16,6 +20,11 @@ class Scope:
         try:
             return self._values[name.lexeme]
         except KeyError:
-            if self._parent is not None:
-                return self._parent.get(name)
             raise EvalError(name, f"name {name.lexeme!r} is not defined") from None
+
+    def get_at(self, depth: int, name: Token) -> Any:
+        ancestor = self
+        for _ in range(depth):
+            assert ancestor.parent is not None
+            ancestor = ancestor.parent
+        return ancestor.get(name)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -194,6 +194,34 @@ def test_cli_repl(monkeypatch: Any, capsys: Any) -> None:
             "9\n",
             id="function-all-kwargs",
         ),
+        pytest.param(
+            """
+            x = 1
+            fn f()
+                return x
+            end
+            print(f())
+            x = 2
+            print(f())
+            """,
+            "1\n2\n",
+            id="resolve-function-globals",
+        ),
+        pytest.param(
+            """
+            x = 1
+            do
+                fn f()
+                    return x
+                end
+                print(f())
+                x = 2
+                print(f())
+            end
+            """,
+            "1\n1\n",
+            id="resolve-block-globals",
+        ),
         ("assert true", ""),
         ("-- Comment", ""),
         ("", ""),

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -368,16 +368,28 @@ def test_cli_eval(source: str, result: str, capsys: Any) -> None:
             """
             fn valid() end
             valid())
-            y = "valid"
-            break
-            z = "ok"
+            y = "valid"+
             """,
             (
                 "[line 3] error: at ')': expected expression\n"
-                "[line 5] error: at 'break': break outside loop\n"
+                "[line 5] error: at end: expected expression\n"
             ),
             65,
             id="parse-error-multiple",
+        ),
+        pytest.param(
+            """
+            return 0
+            break
+            continue
+            """,
+            (
+                "[line 2] error: at 'return': return outside function\n"
+                "[line 3] error: at 'break': break outside loop\n"
+                "[line 4] error: at 'continue': continue outside loop\n"
+            ),
+            65,
+            id="parse-error-resolver",
         ),
         # Runtime errors
         (


### PR DESCRIPTION
Tweak block (`do ... end`) behavior, so that references to global variables from function closures don't leak because of block variables.

This is in the realm of fine details, as hinted here: https://www.craftinginterpreters.com/resolving-and-binding.html